### PR TITLE
Add config_modbus_port option to allow Modbus port to be set (for virtualcoke)

### DIFF
--- a/dispsrv.conf
+++ b/dispsrv.conf
@@ -9,6 +9,8 @@ items_file items.cfg
 # PLC - coke brain
 #coke_modbus_address 130.95.13.73
 coke_modbus_address 0.0.0.0
+# 502 is default modbus port, virtualcoke uses 1502
+coke_modbus_port 502
 
 # Zero price items, defaults to off
 test_mode no

--- a/items.cfg
+++ b/items.cfg
@@ -5,7 +5,7 @@
 # Type	ID	Price	Description
 
 # Drinks
-coke	0	200	X Blue Powerade
+coke	0	200	Blue Powerade
 coke	1	200	Mother Energy Drink
 coke	2	75	Solo
 coke	3	75	Lemonade

--- a/items.cfg
+++ b/items.cfg
@@ -5,7 +5,7 @@
 # Type	ID	Price	Description
 
 # Drinks
-coke	0	200	Blue Powerade
+coke	0	200	X Blue Powerade
 coke	1	200	Mother Energy Drink
 coke	2	75	Solo
 coke	3	75	Lemonade

--- a/src/server/handler_coke.c
+++ b/src/server/handler_coke.c
@@ -49,7 +49,7 @@ tHandler	gCoke_Handler = {
 	Coke_DoDispense
 };
 const char	*gsCoke_ModbusAddress = "130.95.13.73";
- int		gsCoke_ModbusPort = 502;
+ int		giCoke_ModbusPort = 502;
 modbus_t	*gCoke_Modbus;
 time_t	gtCoke_LastDispenseTime;
 time_t	gtCoke_LastReconnectTime;
@@ -127,7 +127,7 @@ int Coke_int_ConnectToPLC(void)
 
 	if( !gCoke_Modbus )
 	{
-		gCoke_Modbus = modbus_new_tcp(gsCoke_ModbusAddress, gsCoke_ModbusPort);
+		gCoke_Modbus = modbus_new_tcp(gsCoke_ModbusAddress, giCoke_ModbusPort);
 		if( !gCoke_Modbus )
 		{
 			perror("coke - modbus_new_tcp");

--- a/src/server/handler_coke.c
+++ b/src/server/handler_coke.c
@@ -49,6 +49,7 @@ tHandler	gCoke_Handler = {
 	Coke_DoDispense
 };
 const char	*gsCoke_ModbusAddress = "130.95.13.73";
+ int		gsCoke_ModbusPort = 502;
 modbus_t	*gCoke_Modbus;
 time_t	gtCoke_LastDispenseTime;
 time_t	gtCoke_LastReconnectTime;
@@ -126,7 +127,7 @@ int Coke_int_ConnectToPLC(void)
 
 	if( !gCoke_Modbus )
 	{
-		gCoke_Modbus = modbus_new_tcp(gsCoke_ModbusAddress, 502);
+		gCoke_Modbus = modbus_new_tcp(gsCoke_ModbusAddress, gsCoke_ModbusPort);
 		if( !gCoke_Modbus )
 		{
 			perror("coke - modbus_new_tcp");

--- a/src/server/main.c
+++ b/src/server/main.c
@@ -31,7 +31,7 @@ extern int	gbServer_RunInBackground;
 extern int	giServer_Port;
 extern const char	*gsItemListFile;
 extern const char	*gsCoke_ModbusAddress;
-extern int	gsCoke_ModbusPort;
+extern int	giCoke_ModbusPort;
 extern const char	*gsDoor_SerialPort;
 extern bool	gbSyslogEnabled;
 
@@ -134,7 +134,7 @@ int main(int argc, char *argv[])
 	gbSyslogEnabled      = (Config_GetValue_Bool("disable_syslog", 0) == 0);
 
 	gsCoke_ModbusAddress = Config_GetValue("coke_modbus_address", 0);
-	gsCoke_ModbusPort    = Config_GetValue_Int("coke_modbus_port", 0);
+	giCoke_ModbusPort    = Config_GetValue_Int("coke_modbus_port", 0);
 
 	signal(SIGINT, sigint_handler);
 	signal(SIGTERM, sigint_handler);

--- a/src/server/main.c
+++ b/src/server/main.c
@@ -31,6 +31,7 @@ extern int	gbServer_RunInBackground;
 extern int	giServer_Port;
 extern const char	*gsItemListFile;
 extern const char	*gsCoke_ModbusAddress;
+extern int	gsCoke_ModbusPort;
 extern const char	*gsDoor_SerialPort;
 extern bool	gbSyslogEnabled;
 
@@ -126,12 +127,14 @@ int main(int argc, char *argv[])
 	gbServer_RunInBackground = Config_GetValue_Bool("daemonise", 0);
 	gsCokebankPath       = Config_GetValue("cokebank_database", 0);
 	gsDoor_SerialPort    = Config_GetValue("door_serial_port", 0);
-	gsCoke_ModbusAddress = Config_GetValue("coke_modbus_address", 0);
 	giServer_Port        = Config_GetValue_Int("server_port", 0);
 	gsItemListFile       = Config_GetValue("items_file", 0);
 
 	gbNoCostMode         = (Config_GetValue_Bool("test_mode", 0) == 1);
 	gbSyslogEnabled      = (Config_GetValue_Bool("disable_syslog", 0) == 0);
+
+	gsCoke_ModbusAddress = Config_GetValue("coke_modbus_address", 0);
+	gsCoke_ModbusPort    = Config_GetValue_Int("coke_modbus_port", 0);
 
 	signal(SIGINT, sigint_handler);
 	signal(SIGTERM, sigint_handler);


### PR DESCRIPTION
Support patch to allow Modbus port to be set.     This is part of the ongoing development work for uccvend-vagrant